### PR TITLE
Fix: Add missing imports in LinkDeviceRepositoryTest

### DIFF
--- a/app/src/test/java/org/thoughtcrime/securesms/linkdevice/LinkDeviceRepositoryTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/linkdevice/LinkDeviceRepositoryTest.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.linkdevice
 
 import android.net.Uri
+import android.util.Base64
 import com.google.protobuf.ByteString
 import org.junit.Before
 import org.junit.Rule
@@ -10,6 +11,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockedStatic
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -17,6 +19,7 @@ import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.signal.libsignal.protocol.ecc.Curve
 import org.signal.libsignal.protocol.IdentityKeyPair
 import org.signal.libsignal.protocol.ecc.ECPublicKey
 import org.thoughtcrime.securesms.crypto.ProfileKeyUtil


### PR DESCRIPTION
I've added the following missing imports to app/src/test/java/org/thoughtcrime/securesms/linkdevice/LinkDeviceRepositoryTest.kt:
- android.util.Base64
- org.signal.libsignal.protocol.ecc.Curve
- org.mockito.Mockito.mock

These imports were identified as missing and were causing compilation errors.